### PR TITLE
Fix for "The app references non-public selctors in ... ignore:"

### DIFF
--- a/Core/HTTPServer.m
+++ b/Core/HTTPServer.m
@@ -758,7 +758,7 @@ static NSThread *bonjourThread;
 	// We can't run the run loop unless it has an associated input source or a timer.
 	// So we'll just create a timer that will never fire - unless the server runs for 10,000 years.
 	
-	[NSTimer scheduledTimerWithTimeInterval:DBL_MAX target:self selector:@selector(ignore:) userInfo:nil repeats:YES];
+	[NSTimer scheduledTimerWithTimeInterval:DBL_MAX target:self selector:@selector(donothingatall:) userInfo:nil repeats:YES];
 	
 	[[NSRunLoop currentRunLoop] run];
 	

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
@@ -6316,7 +6316,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	// So we'll just create a timer that will never fire - unless the server runs for a decades.
 	[NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
 	                                 target:self
-	                               selector:@selector(ignore:)
+	                               selector:@selector(donothingatall:)
 	                               userInfo:nil
 	                                repeats:YES];
 	

--- a/Vendor/CocoaLumberjack/DDLog.m
+++ b/Vendor/CocoaLumberjack/DDLog.m
@@ -653,7 +653,7 @@ typedef struct LoggerNode LoggerNode;
 	
 	// We can't run the run loop unless it has an associated input source or a timer.
 	// So we'll just create a timer that will never fire - unless the server runs for 10,000 years.
-	[NSTimer scheduledTimerWithTimeInterval:DBL_MAX target:self selector:@selector(ignore:) userInfo:nil repeats:NO];
+	[NSTimer scheduledTimerWithTimeInterval:DBL_MAX target:self selector:@selector(donothingatall:) userInfo:nil repeats:NO];
 	
 	[[NSRunLoop currentRunLoop] run];
 	


### PR DESCRIPTION
We submitted an update for a customer app to the App Store and the automatic check for private API during the upload with the Application Uploader complained about the selector "ignore:"

We changed the selector from "ignore:" to "donothingatall:" and the submit was without issues. 
