### PR TITLE
Fixing a typo

### DIFF
--- a/Core/HTTPConnection.m
+++ b/Core/HTTPConnection.m
@@ -1120,9 +1120,9 @@ static NSMutableArray *recentNonces;
 
 - (void)sendResponseHeadersAndBody
 {
-	if ([httpResponse respondsToSelector:@selector(delayResponeHeaders)])
+	if ([httpResponse respondsToSelector:@selector(delayResponseHeaders)])
 	{
-		if ([httpResponse delayResponeHeaders])
+		if ([httpResponse delayResponseHeaders])
 		{
 			return;
 		}

--- a/Core/HTTPResponse.h
+++ b/Core/HTTPResponse.h
@@ -53,7 +53,7 @@
  * 
  * Important: You should read the discussion at the bottom of this header.
 **/
-- (BOOL)delayResponeHeaders;
+- (BOOL)delayResponseHeaders;
 
 /**
  * Status code for response.

--- a/Samples/DynamicServer/HTTPResponseTest.h
+++ b/Samples/DynamicServer/HTTPResponseTest.h
@@ -4,7 +4,7 @@
 @class HTTPConnection;
 
 // 
-// This class is a UnitTest for the delayResponeHeaders capability of HTTPConnection
+// This class is a UnitTest for the delayResponseHeaders capability of HTTPConnection
 // 
 
 @interface HTTPResponseTest : NSObject <HTTPResponse>

--- a/Samples/DynamicServer/HTTPResponseTest.m
+++ b/Samples/DynamicServer/HTTPResponseTest.m
@@ -7,7 +7,7 @@
 static const int httpLogLevel = HTTP_LOG_LEVEL_OFF; // | HTTP_LOG_FLAG_TRACE;
 
 // 
-// This class is a UnitTest for the delayResponeHeaders capability of HTTPConnection
+// This class is a UnitTest for the delayResponseHeaders capability of HTTPConnection
 // 
 
 @interface HTTPResponseTest (PrivateAPI)
@@ -64,7 +64,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_OFF; // | HTTP_LOG_FLAG_TRACE;
 	[connection responseHasAvailableData:self];
 }
 
-- (BOOL)delayResponeHeaders
+- (BOOL)delayResponseHeaders
 {
 	HTTPLogTrace2(@"%@[%p] %@ -> %@", THIS_FILE, self, THIS_METHOD, (readyToSendResponseHeaders ? @"NO" : @"YES"));
 	


### PR DESCRIPTION
Was temporarily scratching my head as to why my overridden "delayResponseHeaders" wasn't getting called. It was just a typo.
