### PR TITLE
Fix for websocket connection issue with Firefox

### DIFF
--- a/Core/WebSocket.m
+++ b/Core/WebSocket.m
@@ -111,7 +111,7 @@ static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame)
 	else if (![upgradeHeaderValue caseInsensitiveCompare:@"WebSocket"] == NSOrderedSame) {
 		isWebSocket = NO;
 	}
-	else if (![connectionHeaderValue caseInsensitiveCompare:@"Upgrade"] == NSOrderedSame) {
+	else if ([connectionHeaderValue rangeOfString:@"Upgrade" options:NSCaseInsensitiveSearch].location == NSNotFound) {
 		isWebSocket = NO;
 	}
 	


### PR DESCRIPTION
As said in https://github.com/robbiehanson/CocoaHTTPServer/issues/20
Firefox is sending the following Connection header field for websockets

Connection:keep-alive, Upgrade

This fix looks for the "Upgrade" keyword (insensitive search) anywhere in the connection value string. 
If found it allows the connection, otherwise it is rejected

The behavior seems to be in firefox since version 7 (at least)
see : https://github.com/Lawouach/WebSocket-for-Python/issues/3
