### PR TITLE
Fix for incorrect file attribute reporting of symlinked files in HTTPFileResponse

### DIFF
--- a/Core/Responses/HTTPFileResponse.m
+++ b/Core/Responses/HTTPFileResponse.m
@@ -27,7 +27,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
 		connection = parent; // Parents retain children, children do NOT retain parents
 		
 		fileFD = NULL_FD;
-		filePath = [fpath copy];
+		filePath = [[fpath copy] stringByResolvingSymlinksInPath];
 		if (filePath == nil)
 		{
 			HTTPLogWarn(@"%@: Init failed - Nil filePath", THIS_FILE);


### PR DESCRIPTION
Today I noticed that on symlinked files only the few bytes (usually ~22) of the file were sent. I poked around and discovered that this was because the file attributes (specifically file size) of the symlink were being read instead of the attributes of the linked to file. Fixed it with a quick oneliner.
