### PR TITLE
Fixed a leak in -(NSString *)hexStringValue

### DIFF
--- a/Core/Categories/DDData.m
+++ b/Core/Categories/DDData.m
@@ -38,7 +38,7 @@ static char encodingTable[64] = {
         [stringBuffer appendFormat:@"%02x", (unsigned int)dataBuffer[i]];
 	}
     
-    return [[stringBuffer copy] autorelease];
+    return [stringBuffer copy];
 }
 
 - (NSString *)base64Encoded


### PR DESCRIPTION
Return value of -hexStringValue has a retain count of +1 => needs an -autorelease. Noticed this leak with the Xcode static analyzer.
