### PR TITLE
Extraneous semi-colons

### DIFF
--- a/Core/HTTPConnection.m
+++ b/Core/HTTPConnection.m
@@ -1977,7 +1977,7 @@ static NSMutableArray *recentNonces;
  * This method is called immediately prior to sending the response headers (for an error).
  * This method adds standard header fields, and then converts the response to an NSData object.
 **/
-- (NSData *)preprocessErrorResponse:(HTTPMessage *)response;
+- (NSData *)preprocessErrorResponse:(HTTPMessage *)response
 {
 	HTTPLogTrace();
 	
@@ -2493,7 +2493,7 @@ static NSMutableArray *recentNonces;
 /**
  * Sent after the socket has been disconnected.
 **/
-- (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err;
+- (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err
 {
 	HTTPLogTrace();
 	


### PR DESCRIPTION
Found 2 methods with semi-colons at the end of their definition. I think this causes the definition to be treated by the compiler as a declaration and the body of the function is never called.
