### PR TITLE
Fix uninitialized-variable error with Xcode 4.6+

### DIFF
--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
@@ -4213,16 +4213,13 @@ enum GCDAsyncSocketConfig
 	
 	if ([self usingCFStreamForTLS])
 	{
-		#if TARGET_OS_IPHONE
-		
-		// Relegated to using CFStream... :( Boo! Give us a full SecureTransport stack Apple!
-		
+        hasBytesAvailable = NO;
 		estimatedBytesAvailable = 0;
+		#if TARGET_OS_IPHONE
+		// Relegated to using CFStream... :( Boo! Give us a full SecureTransport stack Apple!
+
 		if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
 			hasBytesAvailable = YES;
-		else
-			hasBytesAvailable = NO;
-		
 		#endif
 	}
 	else


### PR DESCRIPTION
The version of Clang in Xcode 4.6 now complains about usage of an
uninitialized variable 'hasBytesAvailable' in -[GCDAsyncSocket doReadData].
This breaks compilation. I've added a few lines to initialize the variable.
