### PR TITLE
Parse empty GET keys

### DIFF
--- a/Core/HTTPConnection.m
+++ b/Core/HTTPConnection.m
@@ -692,6 +692,21 @@ static NSMutableArray *recentNonces;
 					}
 				}
 			}
+			else
+			{
+				NSString *escapedKey = component;
+				
+				CFStringRef k;
+				
+				k = CFURLCreateStringByReplacingPercentEscapes(NULL, (__bridge CFStringRef)escapedKey, CFSTR(""));
+				
+				NSString *key;
+				
+				key   = (__bridge_transfer NSString *)k;
+				
+				if (key)
+					[result setObject:[NSNull null] forKey:key];
+			}
 		}
 	}
 	


### PR DESCRIPTION
GET parameters without a value in the URL are not parsed without
this patch; for example `?a&b=1` results in `a` not being included
in the GET params dictionary at all, whereas a NULL value should
probably be present
