### PR TITLE
Always use __weak instead of __unsafe_unretained if available

### DIFF
--- a/Core/HTTPConnection.h
+++ b/Core/HTTPConnection.h
@@ -15,7 +15,11 @@
 
 @interface HTTPConfig : NSObject
 {
+#if __has_feature(objc_arc_weak)
+	HTTPServer __weak *server;
+#else
 	HTTPServer __unsafe_unretained *server;
+#endif
 	NSString __strong *documentRoot;
 	dispatch_queue_t queue;
 }
@@ -23,7 +27,12 @@
 - (id)initWithServer:(HTTPServer *)server documentRoot:(NSString *)documentRoot;
 - (id)initWithServer:(HTTPServer *)server documentRoot:(NSString *)documentRoot queue:(dispatch_queue_t)q;
 
+#if __has_feature(objc_arc_weak)
+@property (nonatomic, weak, readonly) HTTPServer *server;
+#else
 @property (nonatomic, unsafe_unretained, readonly) HTTPServer *server;
+#endif
+
 @property (nonatomic, strong, readonly) NSString *documentRoot;
 @property (nonatomic, readonly) dispatch_queue_t queue;
 

--- a/Core/WebSocket.h
+++ b/Core/WebSocket.h
@@ -19,7 +19,11 @@
 	BOOL isOpen;
 	BOOL isVersion76;
 	
+#if __has_feature(objc_arc_weak)
+	id __weak delegate;
+#else
 	id __unsafe_unretained delegate;
+#endif
 }
 
 + (BOOL)isWebSocketRequest:(HTTPMessage *)request;
@@ -32,7 +36,11 @@
  * In most cases it will be easier to subclass WebSocket,
  * but some circumstances may lead one to prefer standard delegate callbacks instead.
 **/
+#if __has_feature(objc_arc_weak)
+@property (/* atomic */ weak) id delegate;
+#else
 @property (/* atomic */ unsafe_unretained) id delegate;
+#endif
 
 /**
  * The WebSocket class is thread-safe, generally via it's GCD queue.


### PR DESCRIPTION
I saw that this method was being used in other parts of the code, this commit makes it consistent throughout and fixes some crashes we ran into.
