### PR TITLE
Changed HTTPConnection to include option for using a call back method to set httpResponse

### DIFF
--- a/Core/HTTPConnection.h
+++ b/Core/HTTPConnection.h
@@ -17,7 +17,7 @@
 {
 	HTTPServer __unsafe_unretained *server;
 	NSString __strong *documentRoot;
-	dispatch_queue_t queue;
+	dispatch_queue_t __weak queue;
 }
 
 - (id)initWithServer:(HTTPServer *)server documentRoot:(NSString *)documentRoot;
@@ -25,7 +25,7 @@
 
 @property (nonatomic, unsafe_unretained, readonly) HTTPServer *server;
 @property (nonatomic, strong, readonly) NSString *documentRoot;
-@property (nonatomic, readonly) dispatch_queue_t queue;
+@property (weak, nonatomic, readonly) dispatch_queue_t queue;
 
 @end
 
@@ -60,8 +60,10 @@
 	UInt64 requestContentLengthReceived;
 	UInt64 requestChunkSize;
 	UInt64 requestChunkSizeReceived;
-  
+    
 	NSMutableArray *responseDataSizes;
+    
+    BOOL useCallBack;
 }
 
 - (id)initWithAsyncSocket:(GCDAsyncSocket *)newSocket configuration:(HTTPConfig *)aConfig;
@@ -90,9 +92,11 @@
 - (NSArray *)directoryIndexFileNames;
 - (NSString *)filePathForURI:(NSString *)path;
 - (NSString *)filePathForURI:(NSString *)path allowDirectory:(BOOL)allowDirectory;
-//- (NSObject<HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
-- (void)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+- (NSObject<HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+- (void)httpResponseForMethodStart:(NSString *)method URI:(NSString *)path;
 - (void)httpResponseForMethodFinished:(NSObject<HTTPResponse> *)response;
+- (BOOL)useCallBack;
+- (void)setUseCallBack:(BOOL)useCallBack;
 - (WebSocket *)webSocketForURI:(NSString *)path;
 
 - (void)prepareForBodyWithSize:(UInt64)contentLength;


### PR DESCRIPTION
Changed HTTPConnection
    Added property useCallBack, default value of false
    Added method useCallBack
    Added method setUseCallBack:
    Changed method httpResponseForMethod:URI:
    Added method httpResponseForMethodStart:URI:
    Added method httpResponseForMethodFinished:URI:

This change if useCallBack is set to true allows the server to wait to send the response until the app server would like the response sent.  This allows for multithreaded work to be done from the app server before letting the client know the results.

Example: 

A PC (client) ask the iOS device(app server) on same wifi network to start up a process and needs to know if the process was successful or not.  The process on the app server requires the app server to make a call to another server(data server) to get data. When the app server makes a connection to the data server it creates another thread.  

The original design would send the response before the app server's connection to the data server was finished doing it's work.  The new design allows the app server to send a response based on what on interaction with the data server.
