### PR TITLE
handle 64-bit payloads in websocket

### DIFF
--- a/Core/WebSocket.h
+++ b/Core/WebSocket.h
@@ -73,6 +73,7 @@
 **/
 - (void)didOpen;
 - (void)didReceiveMessage:(NSString *)msg;
+- (void)didReceiveData:(NSData *)data;
 - (void)didClose;
 
 @end
@@ -99,6 +100,8 @@
 - (void)webSocketDidOpen:(WebSocket *)ws;
 
 - (void)webSocket:(WebSocket *)ws didReceiveMessage:(NSString *)msg;
+
+- (void)webSocket:(WebSocket *)ws didReceiveData:(NSData *)data;
 
 - (void)webSocketDidClose:(WebSocket *)ws;
 

--- a/Core/WebSocket.m
+++ b/Core/WebSocket.m
@@ -602,6 +602,22 @@ static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame)
 	}
 }
 
+- (void)didReceiveData:(NSData *)data
+{
+	HTTPLogTrace();
+
+	// Override me to process incoming data.
+	// This method is invoked on the websocketQueue.
+	//
+	// For completeness, you should invoke [super didReceiveData:data] in your method.
+
+	// Notify delegate
+	if ([delegate respondsToSelector:@selector(webSocket:didReceiveData:)])
+	{
+		[delegate webSocket:self didReceiveData:data];
+	}
+}
+
 - (void)didClose
 {
 	HTTPLogTrace();
@@ -769,6 +785,10 @@ static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame)
 		{
 			NSString *msg = [[NSString alloc] initWithBytes:[data bytes] length:msgLength encoding:NSUTF8StringEncoding];
 			[self didReceiveMessage:msg];
+		}
+		if (nextOpCode == WS_OP_BINARY_FRAME)
+		{
+			[self didReceiveData:data];
 		}
 		else
 		{


### PR DESCRIPTION
We also needed larger payloads.

This code will take 32-bit lengths (4GB) generally,
and 64-bit lengths (unlikely) on arm64.

Avoiding compile errors by checking for architecture.
