### PR TITLE
Remove kCFStreamSocketSecurityLevelNegotiatedSSL to keep ssl working with current CocoaAsyncSocket

### DIFF
--- a/Core/HTTPConnection.m
+++ b/Core/HTTPConnection.m
@@ -621,8 +621,9 @@ static NSMutableArray *recentNonces;
 						 forKey:(NSString *)kCFStreamSSLCertificates];
 			
 			// Configure this connection to use the highest possible SSL level
-			[settings setObject:(NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL
-						 forKey:(NSString *)kCFStreamSSLLevel];
+			// This is no longer supported by CocoaAsyncSocket
+			//[settings setObject:(NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL
+			//			 forKey:(NSString *)kCFStreamSSLLevel];
 			
 			[asyncSocket startTLS:settings];
 		}


### PR DESCRIPTION
This presumably reduces the security of the server, but the alternative
is crashing with the default subspecs when installed through cocoa pods.
Users can re-enable this if they manually use
pod 'CocoaAsyncSocket', '~> 7.3.5'
