### PR TITLE
fix iOS9 crash problem

### DIFF
--- a/Samples/iPhoneHTTPServer/Classes/iPhoneHTTPServerAppDelegate.m
+++ b/Samples/iPhoneHTTPServer/Classes/iPhoneHTTPServerAppDelegate.m
@@ -55,7 +55,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
     [self startServer];
     
     // Add the view controller's view to the window and display.
-    [window addSubview:viewController.view];
+    [window setRootViewController:viewController];
     [window makeKeyAndVisible];
     
     return YES;


### PR DESCRIPTION
if not use setRootViewController in UIWindow, it will crash in iOS9.
